### PR TITLE
Ignore content past jumps when going through multiple options

### DIFF
--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -455,6 +455,34 @@ it('Can evaluate an assignment from one variable to another via an expression wi
     expect(run.next().done).to.be.true;
   });
 
+  it('Halts when given the <<stop>> command after going through multiple options', () => {
+    runner.load(commandAndFunctionYarnData);
+    const run = runner.run('Option1');
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Prompt1', value.data, value.lineNum));
+    value = run.next().value;
+    value.select(0);
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Prompt2', value.data, value.lineNum));
+    value = run.next().value;
+    value.select(0);
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('First line', value.data, value.lineNum));
+    expect(run.next().done).to.be.true;
+  });
+
+  it('Halts when given the <<stop>> command after going through multiple jumps', () => {
+    runner.load(commandAndFunctionYarnData);
+    const run = runner.run('Jump1');
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text1', value.data, value.lineNum));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text2', value.data, value.lineNum));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('First line', value.data, value.lineNum));
+    expect(run.next().done).to.be.true;
+  });
+
   it('Returns commands to the user', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('BasicCommands');

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -455,7 +455,7 @@ it('Can evaluate an assignment from one variable to another via an expression wi
     expect(run.next().done).to.be.true;
   });
 
-  it('Halts when given the <<stop>> command after going through multiple options', () => {
+  it('Ignores content after jumps when going through multiple options', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('Option1');
     let value = run.next().value;

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -471,18 +471,6 @@ it('Can evaluate an assignment from one variable to another via an expression wi
     expect(run.next().done).to.be.true;
   });
 
-  it('Halts when given the <<stop>> command after going through multiple jumps', () => {
-    runner.load(commandAndFunctionYarnData);
-    const run = runner.run('Jump1');
-    let value = run.next().value;
-    expect(value).to.deep.equal(new bondage.TextResult('Text1', value.data, value.lineNum));
-    value = run.next().value;
-    expect(value).to.deep.equal(new bondage.TextResult('Text2', value.data, value.lineNum));
-    value = run.next().value;
-    expect(value).to.deep.equal(new bondage.TextResult('First line', value.data, value.lineNum));
-    expect(run.next().done).to.be.true;
-  });
-
   it('Returns commands to the user', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('BasicCommands');

--- a/tests/yarn_files/commandsandfunctions.json
+++ b/tests/yarn_files/commandsandfunctions.json
@@ -38,7 +38,48 @@
 			"y": 252
 		},
 		"colorID": 0
-	},	{
+	},	
+        {
+		"title": "Jump1",
+		"tags": "Tag",
+		"body": "Text1\n[[Jump2]]\nThis shouldn't show",
+		"position": {
+			"x": 449,
+			"y": 252
+		},
+		"colorID": 0
+	},
+        {
+		"title": "Jump2",
+		"tags": "Tag",
+		"body": "Text2\n[[StopCommand]]\nThis shouldn't show",
+		"position": {
+			"x": 449,
+			"y": 252
+		},
+		"colorID": 0
+	},
+        {
+		"title": "Option1",
+		"tags": "Tag",
+		"body": "Prompt1\n-> Option 1\n\t[[Option2]]\nThis shouldn't show",
+		"position": {
+			"x": 449,
+			"y": 252
+		},
+		"colorID": 0
+	},
+        {
+		"title": "Option2",
+		"tags": "Tag",
+		"body": "Prompt2\n-> Option 2\n\t[[StopCommand]]\nThis shouldn't show",
+		"position": {
+			"x": 449,
+			"y": 252
+		},
+		"colorID": 0
+	},
+        {
 		"title": "StopCommand",
 		"tags": "Tag",
 		"body": "First line\n<<stop>>\nThis shouldn't show",

--- a/tests/yarn_files/commandsandfunctions.json
+++ b/tests/yarn_files/commandsandfunctions.json
@@ -40,26 +40,6 @@
 		"colorID": 0
 	},	
         {
-		"title": "Jump1",
-		"tags": "Tag",
-		"body": "Text1\n[[Jump2]]\nThis shouldn't show",
-		"position": {
-			"x": 449,
-			"y": 252
-		},
-		"colorID": 0
-	},
-        {
-		"title": "Jump2",
-		"tags": "Tag",
-		"body": "Text2\n[[StopCommand]]\nThis shouldn't show",
-		"position": {
-			"x": 449,
-			"y": 252
-		},
-		"colorID": 0
-	},
-        {
 		"title": "Option1",
 		"tags": "Tag",
 		"body": "Prompt1\n-> Option 1\n\t[[Option2]]\nThis shouldn't show",


### PR DESCRIPTION
See test for the case this pertains to.

Basically, the runner is splitting the node into parts which each get recursively evaluated in a loop. We want to stop the outer loop if we jump or stop at any time in the inner call, ignoring things that come past a jump.